### PR TITLE
Update README.md

### DIFF
--- a/packages/storage-plus/README.md
+++ b/packages/storage-plus/README.md
@@ -409,7 +409,7 @@ fn demo() -> StdResult<()> {
 
 ## IndexedMap
 
-Let's sue one example of `IndexedMap` definition and usage, originally taken from the `cw721-base` contract.
+Let's use one example of `IndexedMap` definition and usage, originally taken from the `cw721-base` contract.
 
 ### Definition
 


### PR DESCRIPTION
fix a typo "sue" -> "use" (or maybe it was supposed to be "see"?)